### PR TITLE
imported routers, serializers, and viewsets from rest to display root…

### DIFF
--- a/backend/jobsboard/urls.py
+++ b/backend/jobsboard/urls.py
@@ -15,11 +15,29 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from django.contrib.auth.models import User
+from rest_framework import routers, serializers, viewsets
 
+# Serializers for API representation
+class UserSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = User
+        fields = ('url', 'username', 'email', 'is_staff')
+
+# ViewSets for defining view behavior
+class UserViewSet(viewsets.ModelViewSet):
+    queryset = User.objects.all()
+    serializer_class = UserSerializer
+
+# Routers for automatically determining the URL configuration
+router = routers.DefaultRouter()
+router.register(r'users', UserViewSet)
+
+
+# Wire up our API using automatic URL routing.
 urlpatterns = [
-   
     # For using API (login and logout views)
-   
+   path('', include(router.urls)),
    path('admin/', admin.site.urls),
-   path('api-auth/', include('rest_framework.urls'))
+   path('api-auth/', include('rest_framework.urls',  namespace='rest_framework'))
 ]


### PR DESCRIPTION
# Description

Added code for routers, serializers and viewsets. I had an error for importing router but realized I added `router.urls` as a string when I changed the format. I have the root displaying status code 200 and this is what I get when I runserver. 

<img width="1105" alt="resultsonpage" src="https://user-images.githubusercontent.com/15254027/45371161-eb87fa80-b5b7-11e8-9a9b-cbcf5412a671.png">

Fixes # (issue)

It wasn't importing `routers`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Test A ---> Screenshot above

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
